### PR TITLE
Update 26.ElasticSearch - 冲突问题处理.md

### DIFF
--- a/docs/20.数据库/15.搜索数据库 - ElasticSearch/26.ElasticSearch - 冲突问题处理.md
+++ b/docs/20.数据库/15.搜索数据库 - ElasticSearch/26.ElasticSearch - 冲突问题处理.md
@@ -111,7 +111,7 @@ Elasticsearch 是分布式的。当文档创建、更新或删除时，新版本
 
 新版不使用**外部版本控制**的 url：`http://127.0.1:9200/shopping/_update/1001?if_seq_no=2&if_primary_term=1`
 
-使用**外部版本控制**的 url：`http://127.0.1:9200/shopping/_update/1001?version=6&version_type=external`，要求只要 url 的 version 大于 ES 的索引 _version 即可。如果等于 3，会报错。
+使用**外部版本控制**的 url：`http://127.0.1:9200/shopping/_doc/1001?version=6&version_type=external`，要求只要 url 的 version 大于 ES 的索引 _version 即可。如果等于 3，会报错。
 
 ![image-20211117124040804](https://fastly.jsdelivr.net/gh/Kele-Bingtang/static/img/ElasticSearch/20211117124836.png)
 


### PR DESCRIPTION
使用外部版本控制的 url ,应该是http://127.0.1:9200/shopping/_doc/1001?version=6&version_type=external,不应该是http://127.0.1:9200/shopping/_update/1001?version=6&version_type=external   也就是(_update改为_doc)